### PR TITLE
Move info & email banners inside fixed navbar

### DIFF
--- a/public/css/developer-search.css
+++ b/public/css/developer-search.css
@@ -1683,7 +1683,6 @@ button.pagination-link {
     right: 0;
     z-index: 50;
     background-color: var(--bg-primary);
-    box-shadow: var(--shadow-sm);
     border-bottom: 1px solid var(--border-primary);
     transition: all 0.3s ease-out;
 }
@@ -1706,7 +1705,7 @@ button.pagination-link {
 }
 
 .navbar-spacer {
-    height: 105px;
+    height: 160px;
 }
 
 .navbar-container {
@@ -2025,13 +2024,12 @@ html.dark .dark-mode-icon.moon-icon {
 
 /* Info Banner */
 .info-banner {
-    background: linear-gradient(135deg, var(--color-primary-light) 0%, var(--color-secondary-light) 100%);
-    border-top: 1px solid var(--border-primary);
-    border-bottom: 1px solid var(--color-gray-200);
+    background: linear-gradient(135deg, rgba(0, 136, 210, 0.1) 0%, rgba(0, 136, 210, 0.05) 100%);
+    border-top: 1px solid rgba(0, 136, 210, 0.2);
+    border-bottom: 1px solid rgba(0, 136, 210, 0.2);
     padding: var(--spacing-md) 0;
-    max-height: 50px;
+    max-height: 100px;
     transition: max-height 0.3s ease-out, padding 0.3s ease-out, opacity 0.3s ease-out;
-    overflow: hidden;
 }
 
 .navbar.scrolled .info-banner {
@@ -2071,24 +2069,40 @@ html.dark .dark-mode-icon.moon-icon {
     line-height: 1.5;
 }
 
+@keyframes marquee {
+    0%, 5% { transform: translateX(0); }
+    100% { transform: translateX(-100%); }
+}
+
 @media (max-width: 768px) {
+    .navbar-spacer {
+        height: 120px;
+    }
+
     .info-banner {
-        padding: var(--spacing-sm) 0;
+        padding: var(--spacing-xs) 0;
+        max-height: 32px;
+        overflow: hidden;
     }
-    
+
     .info-banner-container {
-        padding: 0 var(--spacing-md);
+        padding: 0 0 0 var(--spacing-lg);
+        overflow: hidden;
     }
-    
+
     .info-banner-content {
-        flex-direction: column;
-        gap: var(--spacing-xs);
+        flex-direction: row;
+        justify-content: flex-start;
+        gap: var(--spacing-sm);
+        white-space: nowrap;
+        display: inline-flex;
+        animation: marquee 30s linear infinite;
     }
-    
+
     .info-banner-text {
         font-size: var(--font-size-xs);
     }
-    
+
     .info-banner-icon {
         width: 1rem;
         height: 1rem;
@@ -2101,6 +2115,16 @@ html.dark .dark-mode-icon.moon-icon {
     border-bottom: 1px solid rgba(245, 158, 11, 0.3);
     padding: var(--spacing-md) 0;
     position: relative;
+    max-height: 100px;
+    transition: max-height 0.3s ease-out, padding 0.3s ease-out, opacity 0.3s ease-out;
+}
+
+.navbar.scrolled .email-check-banner {
+    max-height: 0;
+    padding: 0;
+    overflow: hidden;
+    border: none;
+    opacity: 0;
 }
 
 .email-check-banner-container {
@@ -2139,22 +2163,29 @@ html.dark .dark-mode-icon.moon-icon {
 
 @media (max-width: 768px) {
     .email-check-banner {
-        padding: var(--spacing-sm) 0;
+        padding: var(--spacing-xs) 0;
+        max-height: 32px;
+        overflow: hidden;
     }
-    
+
     .email-check-banner-container {
-        padding: 0 var(--spacing-md);
+        padding: 0 0 0 var(--spacing-lg);
+        overflow: hidden;
     }
-    
+
     .email-check-banner-content {
-        flex-direction: column;
-        gap: var(--spacing-xs);
+        flex-direction: row;
+        justify-content: flex-start;
+        gap: var(--spacing-sm);
+        white-space: nowrap;
+        display: inline-flex;
+        animation: marquee 32s linear infinite;
     }
-    
+
     .email-check-banner-text {
         font-size: var(--font-size-xs);
     }
-    
+
     .email-check-banner-icon {
         width: 1rem;
         height: 1rem;

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -95,20 +95,6 @@
         @stack('styles')
     </head>
     <body>
-        <!-- Email Check Banner -->
-        <div class="email-check-banner">
-            <div class="email-check-banner-container">
-                <div class="email-check-banner-content">
-                    <svg class="email-check-banner-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                    </svg>
-                    <p class="email-check-banner-text">
-                        <strong>Important:</strong> After registering as a developer, please check the email address you registered with. We will send important updates and login credentials to that email.
-                    </p>
-                </div>
-            </div>
-        </div>
-
         <!-- Navigation -->
         <nav class="navbar"
              x-data="{ mobileMenuOpen: false, scrolled: false }"
@@ -210,6 +196,20 @@
                         <p class="info-banner-text">
                             <strong>Open Source!</strong> FindDeveloper is open source. If you find it useful, give us a star on GitHub — it helps us grow and improve!
                             <a href="https://github.com/ht3aa/find-developer" target="_blank" rel="noopener noreferrer" style="color: var(--color-primary); text-decoration: underline; font-weight: 600; margin-left: 0.5rem;">Star on GitHub →</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Email Check Banner -->
+            <div class="email-check-banner">
+                <div class="email-check-banner-container">
+                    <div class="email-check-banner-content">
+                        <svg class="email-check-banner-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                        </svg>
+                        <p class="email-check-banner-text">
+                            <strong>Important:</strong> After registering as a developer, please check the email address you registered with. We will send important updates and login credentials to that email.
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Moved both banners (open-source info + email check) inside the `<nav>` so they sit flush against the navbar with no gap
- Both banners smoothly collapse/hide when scrolling triggers the floating pill navbar effect
- Info banner uses a soft light blue background matching the site's primary brand color
- On mobile, both banners use a horizontal marquee ticker to save vertical space
- Removed navbar box-shadow for a cleaner appearance

## Test plan
- [ ] Page load: navbar + both banners appear flush together, no gap
- [ ] Scroll down: both banners smoothly collapse, navbar transitions to floating pill
- [ ] Scroll back up: both banners reappear smoothly
- [ ] Mobile: banners show as single-line horizontal tickers with left padding
- [ ] Mobile: marquee starts visible, pauses briefly, then scrolls
- [ ] Dark mode: colors remain correct
- [ ] Hamburger menu still works on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)