### PR TITLE
Add workflow: release tag on merge to main (triggers prod deploy)

### DIFF
--- a/.github/workflows/main-merge-release.yml
+++ b/.github/workflows/main-merge-release.yml
@@ -19,23 +19,30 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - name: Build release tag from merge
+      - name: Checkout merge commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Next semver tag (vX.X.X-main)
         id: tag
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
           set -euo pipefail
-          DATE=$(date -u +%Y.%m.%d)
-          SLUG=$(printf '%s' "$PR_TITLE" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/^-//;s/-$//' | cut -c1-50 | sed 's/-$//')
-          if [ -z "$SLUG" ]; then
-            SLUG="merge"
+          LATEST=$(git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-main$' | sort -V | tail -1 || true)
+          if [ -z "${LATEST:-}" ]; then
+            NEW="v1.0.0-main"
+          else
+            VER="${LATEST#v}"
+            VER="${VER%-main}"
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$VER"
+            PATCH=$((PATCH + 1))
+            NEW="v${MAJOR}.${MINOR}.${PATCH}-main"
           fi
-          SHORT_SHA="${MERGE_SHA:0:7}"
-          TAG="${DATE}-main-pr${PR_NUMBER}-${SLUG}-${SHORT_SHA}"
-          echo "Derived tag: $TAG"
-          echo "tag_name=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Previous semver tag (if any): ${LATEST:-<none>}"
+          echo "Derived tag: $NEW"
+          echo "tag_name=$NEW" >> "$GITHUB_OUTPUT"
 
       - name: Publish release (triggers prod deployment)
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `.github/workflows/main-merge-release.yml`, which runs **only when a pull request targeting `main` is merged** (`pull_request` / `closed` + `merged == true`).

For each merge it:

1. **Checks out the merge commit** with full tag history.
2. **Builds the next tag** as **`vMAJOR.MINOR.PATCH-main`** (e.g. `v1.2.0-main`): finds the latest tag matching `vX.X.X-main`, bumps the **patch** by one; if none exist, starts at **`v1.0.0-main`**.
3. **Publishes a GitHub release** with `generate_release_notes: true`.
4. **Reuses production deployment**: `release: published` triggers `prod-deployment.yml` (tag must contain `main`).

Direct pushes to `main` without a PR merge do not run this workflow.

## Testing

PHP was not available in the cloud agent environment, so `php artisan test` was not run. Only workflow YAML changed.

## Semver note

Only tags matching **`^v[0-9]+\.[0-9]+\.[0-9]+-main$`** participate in version calculation. **Major/minor** bumps are not inferred from PR labels yet; every merge increments **patch**. Say if you want label-driven minor/major bumps (e.g. `release/minor`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6ef69c7-51a5-444f-a164-75847bbaca43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6ef69c7-51a5-444f-a164-75847bbaca43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

