### PR TITLE
Align Mailtrap notification emails with amber brand template

### DIFF
--- a/app/Notifications/MailtrapBulkNotification.php
+++ b/app/Notifications/MailtrapBulkNotification.php
@@ -52,32 +52,10 @@ class MailtrapBulkNotification extends Notification implements ShouldQueue
      */
     protected function getHtmlMessage(): string
     {
-        return "<!DOCTYPE html>
-<html>
-<head>
-    <meta charset='utf-8'>
-    <style>
-        body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
-        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
-        .header { background-color:rgb(0, 49, 173); color: white; padding: 20px; text-align: center; }
-        .content { padding: 20px; background-color: #f9f9f9; }
-        .footer { text-align: center; padding: 20px; font-size: 12px; color: #666; }
-    </style>
-</head>
-<body>
-    <div class='container'>
-        <div class='header'>
-            <h1>".htmlspecialchars($this->subject)."</h1>
-        </div>
-        <div class='content'>
-            <p>".nl2br(htmlspecialchars($this->message))."</p>
-        </div>
-        <div class='footer'>
-            <p>This email was sent via Mailtrap Bulk API</p>
-        </div>
-    </div>
-</body>
-</html>";
+        return view('emails.mailtrap-notification', [
+            'subject' => $this->subject,
+            'message' => $this->message,
+        ])->render();
     }
 
     /**

--- a/app/Notifications/MailtrapNotification.php
+++ b/app/Notifications/MailtrapNotification.php
@@ -53,33 +53,10 @@ class MailtrapNotification extends Notification implements ShouldQueue
      */
     protected function getHtmlMessage(): string
     {
-        return "<!DOCTYPE html>
-<html>
-<head>
-    <meta charset='utf-8'>
-    <link rel='icon' href='".e(asset('logo.svg'))."' type='image/svg+xml'>
-    <style>
-        body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
-        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
-        .header { background-color:rgb(0, 49, 173); color: white; padding: 20px; text-align: center; }
-        .content { padding: 20px; background-color: #f9f9f9; }
-        .footer { text-align: center; padding: 20px; font-size: 12px; color: #666; }
-    </style>
-</head>
-<body>
-    <div class='container'>
-        <div class='header'>
-            <h1>".htmlspecialchars($this->subject)."</h1>
-        </div>
-        <div class='content'>
-            <p>".nl2br(htmlspecialchars($this->message))."</p>
-        </div>
-        <div class='footer'>
-            <p>This email was sent via Mailtrap</p>
-        </div>
-    </div>
-</body>
-</html>";
+        return view('emails.mailtrap-notification', [
+            'subject' => $this->subject,
+            'message' => $this->message,
+        ])->render();
     }
 
     /**

--- a/resources/views/emails/mailtrap-notification.blade.php
+++ b/resources/views/emails/mailtrap-notification.blade.php
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="{{ asset('logo.svg') }}" type="image/svg+xml">
+    <style>
+        /* Matches app UI: primary amber, primary-foreground dark */
+        body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; margin: 0; padding: 0; }
+        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+        .header { background-color: hsl(38, 92%, 50%); color: hsl(38, 15%, 10%); padding: 20px; text-align: center; }
+        .content { padding: 20px; background-color: #f9f9f9; }
+        .message { background: white; padding: 15px; border-radius: 5px; margin: 15px 0; border: 1px solid #ddd; }
+        .footer { text-align: center; padding: 20px; font-size: 12px; color: #666; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>{{ $subject }}</h1>
+        </div>
+        <div class="content">
+            <div class="message">
+                {!! nl2br(e($message)) !!}
+            </div>
+        </div>
+        <div class="footer">
+            <p>&copy; {{ date('Y') }} {{ config('app.name') }}. All rights reserved.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/tests/Feature/MailtrapNotificationTemplateTest.php
+++ b/tests/Feature/MailtrapNotificationTemplateTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Models\User;
+use App\Notifications\MailtrapBulkNotification;
+use App\Notifications\MailtrapNotification;
+
+it('renders mailtrap notification html with primary amber branding', function () {
+    $user = User::factory()->create();
+    $notification = new MailtrapNotification('Weekly update', "Hello\nThere");
+    $message = $notification->toMailtrap($user);
+
+    expect($message->html)
+        ->toContain('hsl(38, 92%, 50%)')
+        ->toContain('Weekly update')
+        ->toContain('Hello')
+        ->not->toContain('rgb(0, 49, 173)');
+});
+
+it('renders mailtrap bulk notification html with primary amber branding', function () {
+    $user = User::factory()->create();
+    $notification = new MailtrapBulkNotification(['a@example.com'], 'Bulk subject', "Line one\nLine two");
+    $message = $notification->toMailtrapBulk($user);
+
+    expect($message->html)
+        ->toContain('hsl(38, 92%, 50%)')
+        ->toContain('Bulk subject')
+        ->toContain('Line one')
+        ->not->toContain('rgb(0, 49, 173)');
+});


### PR DESCRIPTION
Replace inline blue header HTML with a shared Blade view matching other transactional emails (hsl primary amber, message card, app footer). Add feature tests asserting branded colors and no legacy blue header.

Made-with: Cursor