### PR TITLE
Add activity_log.attribute_changes migration for Spatie activity log

### DIFF
--- a/database/migrations/2026_04_02_173036_add_attribute_changes_to_activity_log_table.php
+++ b/database/migrations/2026_04_02_173036_add_attribute_changes_to_activity_log_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('activity_log')) {
+            return;
+        }
+
+        if (Schema::hasColumn('activity_log', 'attribute_changes')) {
+            return;
+        }
+
+        Schema::table('activity_log', function (Blueprint $table) {
+            $table->json('attribute_changes')->nullable()->after('causer_type');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('activity_log')) {
+            return;
+        }
+
+        if (! Schema::hasColumn('activity_log', 'attribute_changes')) {
+            return;
+        }
+
+        Schema::table('activity_log', function (Blueprint $table) {
+            $table->dropColumn('attribute_changes');
+        });
+    }
+};

--- a/tests/Feature/ActivityLogSchemaTest.php
+++ b/tests/Feature/ActivityLogSchemaTest.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+
+it('includes attribute_changes on activity_log for spatie activity log', function () {
+    expect(Schema::hasTable('activity_log'))->toBeTrue();
+    expect(Schema::hasColumn('activity_log', 'attribute_changes'))->toBeTrue();
+});


### PR DESCRIPTION
Older databases may lack attribute_changes while the package expects it. Migration is idempotent. Feature test asserts the column exists after migrate.

Made-with: Cursor