### PR TITLE
Fix dashboard badges index error (uer typo) via regression test

### DIFF
--- a/tests/Feature/DashboardBadgeIndexTest.php
+++ b/tests/Feature/DashboardBadgeIndexTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Models\Badge;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+use Spatie\Permission\Models\Permission;
+
+it('renders the dashboard badges index for users who may view badges', function () {
+    Permission::findOrCreate('ViewAny:Badge', 'web');
+
+    $user = User::factory()->create();
+    $user->givePermissionTo('ViewAny:Badge');
+
+    Badge::factory()->create(['name' => 'Laravel Pro']);
+
+    $this->actingAs($user)
+        ->get(route('badges.index'))
+        ->assertSuccessful()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('Badges/Index')
+            ->has('badges', 1)
+            ->where('badges.0.name', 'Laravel Pro')
+            ->has('can', fn (Assert $can) => $can
+                ->has('updateBadge')
+                ->has('deleteBadge')));
+});


### PR DESCRIPTION
## Problem

The server dump `a2828d95-b146-4646-868d-e263b8dd3f38` reported:

`BadMethodCallException: Method App\\Http\\Requests\\Dashboard\\BadgeIndexRequest::uer does not exist.`

That happens when `BadgeController::index` calls `$request->uer()` instead of `$request->user()` (a typo). Laravel resolves unknown methods on the request via `__call`, which surfaces as a missing method on the form request class.

## Change

- **Regression test:** `GET /dashboard/badges` (`badges.index`) for a user with `ViewAny:Badge` asserts a successful Inertia response with expected props (`badges`, `can.updateBadge`, `can.deleteBadge`).

`main` already uses `$request->user()` in `BadgeController::index`; the test prevents this route from breaking again if the typo is reintroduced.

## Verification

- `php artisan test --compact tests/Feature/DashboardBadgeIndexTest.php`
- `vendor/bin/pint --dirty --format agent`

Made with [Cursor](https://cursor.com)