### PR TITLE
test: guard dashboard badges index developer count query

### DIFF
--- a/tests/Feature/DashboardBadgesIndexTest.php
+++ b/tests/Feature/DashboardBadgesIndexTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Models\Badge;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+it('loads dashboard badges index for super admin with developer counts', function () {
+    $superEmail = 'superadmin-badges-index@example.com';
+    config(['app.super_admin_emails' => $superEmail]);
+    $user = User::factory()->create(['email' => $superEmail]);
+    $this->actingAs($user);
+
+    $badge = Badge::factory()->create(['name' => 'Dashboard Badge Index']);
+
+    $response = $this->get(route('badges.index'));
+
+    $response->assertOk()->assertInertia(fn (Assert $page) => $page
+        ->component('Badges/Index')
+        ->has('badges', 1)
+        ->where('badges.0.id', $badge->id)
+        ->where('badges.0.developers_count', 0));
+});


### PR DESCRIPTION
## Problem

Server error dump `bff6f01e-8089-4cee-8f2f-5717823427a9`: `BadMethodCallException` — `Call to undefined method App\\Models\\Badge::deelopers()`.

`BadgeController::index` was calling `withCount('deelopers')` (typo). The `Badge` model defines `developers()`, not `deelopers()`, so Eloquent could not resolve the relationship and threw when loading `/dashboard/badges`.

## Change

- Add a Pest feature test that hits `route('badges.index')` as a super admin and asserts Inertia receives `developers_count` on each badge. That exercises `withCount('developers')` and will fail if the relationship name is mistyped again.

`main` already uses `withCount('developers')`; this locks the behavior in with CI.

## Checks

- `php artisan test --compact tests/Feature/DashboardBadgesIndexTest.php`
- `vendor/bin/pint --dirty`

Made with [Cursor](https://cursor.com)