### PR TITLE
Guard home route: require DeveloperController (fix dump fdb5ec53)

### DIFF
--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -1,7 +1,17 @@
 <?php
 
+use App\Http\Controllers\DeveloperController;
+use Illuminate\Support\Facades\Route;
+
 test('returns a successful response', function () {
     $response = $this->get(route('home'));
 
     $response->assertOk();
+});
+
+test('home route targets DeveloperController', function () {
+    $route = Route::getRoutes()->getByName('home');
+
+    expect($route)->not->toBeNull()
+        ->and($route->getControllerClass())->toBe(DeveloperController::class);
 });


### PR DESCRIPTION
## Problem
Server error: `BindingResolutionException` — `Target class [DeveloerController] does not exist.` (typo for `DeveloperController` on the named `home` route).

## Resolution
`origin/main` already registers `DeveloperController` for `/`. The failure in the dump matches an unstaged/local typo in `routes/web.php`; restoring that file to match main removes the 500.

## Change
- Add a feature test that asserts the `home` route’s controller class is `DeveloperController`, so a mis-typed controller fails in CI instead of only at runtime.

## Verification
- `php artisan test --compact tests/Feature/ExampleTest.php`
- `vendor/bin/pint --dirty --format agent`

Made with [Cursor](https://cursor.com)